### PR TITLE
Fix confluence cell phone and magic mirror tp not working correct out of the over world

### DIFF
--- a/kubejs/client_scripts/display_item_activation.js
+++ b/kubejs/client_scripts/display_item_activation.js
@@ -1,0 +1,6 @@
+NetworkEvents.dataReceived('displayItemActivation', event => {
+    let itemStack = Item.of(event.data.item);
+    if (!itemStack.isEmpty()) {
+        Client.gameRenderer.displayItemActivation(itemStack);
+    }
+})

--- a/kubejs/server_scripts/fix_confluence_recall.js
+++ b/kubejs/server_scripts/fix_confluence_recall.js
@@ -1,0 +1,22 @@
+ItemEvents.rightClicked((event) => {
+  const player = event.player;
+  const item = event.item;
+
+  if (item.id != "confluence:cell_phone" && item.id != "confluence:magic_mirror") {
+    return;
+  }
+
+  player.server.scheduleInTicks(18, () => {
+    if (!player.isUsingItem() || player.mainHandItem.id != item.id) {
+      return;
+    }
+
+    var pos = player.getRespawnPosition();
+    var dim = player.getRespawnDimension().location();
+    player.server.runCommandSilent(`execute in ${dim} run tp ${player.username} ${pos.x} ${pos.y} ${pos.z}`);
+    player.server.runCommandSilent(`execute in ${dim} run playsound confluence:transmission master ${player.username} ${pos.x} ${pos.y} ${pos.z}`);
+    player.sendData('displayItemActivation', {item: item.id});
+
+    event.cancel();
+  });
+});


### PR DESCRIPTION
I intercept the use event of both, confluence:cell_phone and confluence:magic_mirror to tp the players for the correct dimension instead of sent they to the overworld cordinates in other dimensions, 

_Sometimes, I was sent to above the nether bedrock, and it was sad ;-;_