### PR TITLE
Fix minimap obscuring biome title popups from Traveller titles

### DIFF
--- a/config/travelerstitles-forge-1_20.toml
+++ b/config/travelerstitles-forge-1_20.toml
@@ -37,7 +37,7 @@
 		# If Horizontally Center Title is enabled, this number is relative to the center of the screen.
 		# If Horizontally Center Title is disabled, this number is relative to the top of the screen.
 		# Default: -33.0
-		"Text Y Offset" = -93
+		"Text Y Offset" = -78
 		# The text's horizontal position on the screen.
 		# If Horizontally Center Title is enabled, this number is relative to the center of the screen.
 		# If Horizontally Center Title is disabled, this number is relative to the left side of the screen.

--- a/config/travelerstitles-forge-1_20.toml
+++ b/config/travelerstitles-forge-1_20.toml
@@ -42,7 +42,7 @@
 		# If Horizontally Center Title is enabled, this number is relative to the center of the screen.
 		# If Horizontally Center Title is disabled, this number is relative to the left side of the screen.
 		# Default: 0.0
-		"Text X Offset" = -320
+		"Text X Offset" = 0
 		# Biomes that should not have any title displayed when the player enters them.
 		# Example: "[minecraft:plains, minecraft:desert]"
 		# Default: "[minecraft:the_end, minecraft:river, minecraft:frozen_river]"

--- a/config/travelerstitles-forge-1_20.toml
+++ b/config/travelerstitles-forge-1_20.toml
@@ -29,7 +29,7 @@
 		"Default Text Color" = "ffffff"
 		# The text's scale.
 		# Default: 2.1
-		"Text Size" = 1.1
+		"Text Size" = 1.5
 		# If enabled, will render a shadow below the text making it easier to read.
 		# Default: true
 		"Display Text Shadow" = true
@@ -37,7 +37,7 @@
 		# If Horizontally Center Title is enabled, this number is relative to the center of the screen.
 		# If Horizontally Center Title is disabled, this number is relative to the top of the screen.
 		# Default: -33.0
-		"Text Y Offset" = -202
+		"Text Y Offset" = -93
 		# The text's horizontal position on the screen.
 		# If Horizontally Center Title is enabled, this number is relative to the center of the screen.
 		# If Horizontally Center Title is disabled, this number is relative to the left side of the screen.


### PR DESCRIPTION
Changed the Text X Offset to 0 for title positioning.

This is intended to prevent issues with the minimap obscuring the biome titles - which does happen
on my screen on 1440p with 3x scaling

at the bottom I include a table of screenshots for final config version - the following screens were made during development while I was adjusting - looking for a good compromise between different offsets


### Before - top left

issue showcase - in my preferred 1440p 3x interface setup, the minimap obscures the biome title

<img width="2559" height="1418" alt="image" src="https://github.com/user-attachments/assets/f324f830-06bc-4493-8857-6570324a57e4" />

<img width="2559" height="1415" alt="image" src="https://github.com/user-attachments/assets/cefa6ece-3adb-44f0-a8a6-0afd8f016ccd" />


### After - idea to solve - use top center instead

1440p 3x:

<img width="2559" height="1412" alt="image" src="https://github.com/user-attachments/assets/0bcec86c-25af-4ddf-bb46-cf399d5415b1" />

---

1080p 3x:

<img width="1919" height="1054" alt="image" src="https://github.com/user-attachments/assets/bd72d0a4-8fae-4d6c-955c-d4b5918eb0af" />



### Potential risks

For corner cases - On supersmall or superbig scaling, the title might be either too close to the crosshair (distracting, obscuring), clash with the waila popup, or completely stick out outside of the screen

1080p 1x:

<img width="1919" height="1060" alt="image" src="https://github.com/user-attachments/assets/814be25c-fad6-47ab-86e9-46e68ef91afa" />

---

1080p 4x:

<img width="1919" height="1056" alt="image" src="https://github.com/user-attachments/assets/920eb786-b30e-4071-8611-e9b3b1191640" />


### Full showcase

previous screenshots are from windowed mode (stretched to cover the whole screen)

here are ones made in borderless fullscreen mode, in a more controlled environment, for my final version, on windows 11 with 100% screen scaling:

| res | x1 | x2 | x3 | x4 | x5 | x6 |
|--------|--------|--------|--------|--------|---|--|
| FHD | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/40e008a9-cb6b-4e7d-87c7-def98f5341af" /> | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/bd9b1814-414a-461c-b7cd-9540cb00843b" /> | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/5b91e61e-cab9-4c3c-9daa-75bec9347978" /> | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/34ec45e8-4351-4e16-b1b6-dc7a3631bd6a" /> | n/a  | n/a  |
| QHD | <img width="2559" height="1438" alt="image" src="https://github.com/user-attachments/assets/4ff55179-60e5-4344-8df6-948a992e63ea" /> | <img width="2559" height="1438" alt="image" src="https://github.com/user-attachments/assets/32889330-0360-4920-b708-ce78a606d1d2" /> | <img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/4a7a75bc-2070-49af-b61e-31537bcf17c8" /> | <img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/5b7cec38-b7ff-4d8b-8e42-8614680fa16b" /> | <img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/26a3775b-0ae3-4c96-a49f-9d9918d356ab" /> | <img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/9b0a1022-b116-464a-999d-f180090fb9f3" /> |

